### PR TITLE
suppression d'exercice non prise en compte

### DIFF
--- a/src/js/mathalea.js
+++ b/src/js/mathalea.js
@@ -82,6 +82,10 @@ function ajout_handlers_etiquette_exo () {
       copier_vers_exercice_form()
       $('.choix_exercices:last').focus()
     }
+	if ((e.which === 8 || e.which === 46) && (e.target.innerText === '' || e.target.innerText === '\n')) { // suppression de l'étiquette.
+      copier_vers_exercice_form()
+      $('.choix_exercices:last').focus()
+    }
   })
   $('#choix_exercices_div').sortable({ cancel: 'i', placeholder: 'sortableplaceholder', update: function () { copier_vers_exercice_form() } })
   $('.choix_exercices').off('mousedown').on('mousedown', function () {


### PR DESCRIPTION
On pouvait supprimer une étiquette exercice sans que cela ne soit validé => cela générait donc un décalage d'affichage et rendait possible la visualisation du bouton "nouvelles données" à tort