### PR TITLE
refacto gestion feedback (plus d'id pour éviter les collisions, et simplifier les listeners)

### DIFF
--- a/src/js/mathalea.js
+++ b/src/js/mathalea.js
@@ -205,7 +205,7 @@ if (document.getElementById('choix_exercices_div')) { // On cache le formulaire 
  * soit résolue avant d'utiliser ce qui est chargé (et gérer l'éventuel pb de chargement)
  * @param isdiaporama
  * @param listeObjetsExercice
- * @return {Promise<>}
+ * @return {Promise<undefined>}
  */
 async function gestionModules (isdiaporama, listeObjetsExercice) { // besoin katex, mg32, iep, scratch
   // appelée dès lors que l'on affiche le code html des exercices : depuis "miseAJourDuCode" en mode html (diaporama et !diaporama) et pour le preview.
@@ -225,25 +225,21 @@ async function gestionModules (isdiaporama, listeObjetsExercice) { // besoin kat
     variation: 'inverted',
     inline: true
   })
-  try {
-    const exosMg32 = listeObjetsExercice.filter(exo => exo.typeExercice === 'MG32')
-    if (exosMg32.length) {
-    // faut charger mathgraph et lui filer ces figures
-      try {
-      // faut attendre que le div soit créé
-      // @todo ce code devrait plutôt être exécuté après la création du div
-      // (et ce serait même mieux d'ajouter les conteneurs comme propriétés des exos passés à mg32DisplayAll
-      // => il n'y aurait plus de couplage sur le préfixe MG32div)
-        await waitFor('MG32div0')
-        await mg32DisplayAll(exosMg32)
-      } catch (error) {
-      // On traite l'erreur
-        console.log(error)
-        throw ({ code: 'mg32load' })
-      }
+  const exosMg32 = listeObjetsExercice.filter(exo => exo.typeExercice === 'MG32')
+  if (exosMg32.length) {
+  // faut charger mathgraph et lui filer ces figures
+    try {
+    // faut attendre que le div soit créé
+    // @todo ce code devrait plutôt être exécuté après la création du div
+    // (et ce serait même mieux d'ajouter les conteneurs comme propriétés des exos passés à mg32DisplayAll
+    // => il n'y aurait plus de couplage sur le préfixe MG32div)
+      await waitFor('MG32div0')
+      await mg32DisplayAll(exosMg32)
+    } catch (error) {
+    // On traite l'erreur
+      console.log(error)
+      messageUtilisateur({ code: 'mg32load' })
     }
-  } catch (error) {
-    messageUtilisateur(error)
   }
   try {
     const besoinScratch = listeObjetsExercice.some(exo => exo.typeExercice === 'Scratch')

--- a/src/js/modules/dom.js
+++ b/src/js/modules/dom.js
@@ -1,0 +1,109 @@
+/**
+ * Fonctions de gestion du dom
+ * @module
+ */
+/**
+ * Retourne true si l'objet à la propriété
+ * @param {Object} object
+ * @param {string} prop
+ * @return {boolean}
+ */
+const hasProp = (object, prop) => typeof object === 'object' && Object.prototype.hasOwnProperty.call(object, prop)
+
+/**
+ * Affecte des styles à un élément html (on peut pas affecter elt.style directement car read only, faut faire du elt.style.foo = bar)
+ * sans planter en cas de pb (on le signale juste en console)
+ * @param {HTMLElement} elt
+ * @param {string|object} styles
+ */
+function setStyles (elt, styles) {
+  try {
+    if (elt && elt.style) {
+      if (typeof styles === 'string') {
+        styles = styles.split(';')
+        styles.forEach(function (paire) {
+          paire = /([\w]+):(.+)/.exec(paire)
+          if (paire) {
+            const [, key, value] = paire
+            elt.style[key] = value
+          }
+        })
+      } else if (typeof styles === 'object') {
+        for (var prop in styles) {
+          if (hasProp(styles, prop)) {
+            elt.style[prop] = styles[prop]
+          }
+        }
+      }
+    }
+  } catch (error) {
+    console.error(error)
+  }
+}
+
+/**
+ * Ajoute du texte dans un élément
+ * @param {HTMLElement} elt
+ * @param {string} text
+ */
+export function addText (elt, text) {
+  elt.appendChild(window.document.createTextNode(text))
+}
+
+/**
+ * Retourne l'élément du dom
+ * @param {string} id
+ * @param {boolean} [strict=true] Passer false pour retourner null plutôt que throw une erreur si id n'existe pas
+ * @return {HTMLElement}
+ * @throws {TypeError} Si id n'est pas une string
+ * @throws {Error} Si l'élément id n'existe pas
+ */
+export function get (id, strict = true) {
+  if (typeof id !== 'string') throw TypeError('argument invalide')
+  const elt = document.getElementById(id)
+  if (!elt && strict) throw Error(`L’élément html ${id} n’existe pas`)
+  return elt
+}
+
+/**
+ * Retourne un élément html de type tag (non inséré dans le dom)
+ * @param {string} tag
+ * @param {Object} [attrs] Les attributs
+ * @param {string} [txtContent] Contenu textuel éventuel
+ */
+export function create (tag, attrs, txtContent) {
+  const elt = window.document.createElement(tag)
+  let attr
+  try {
+    if (attrs) {
+      for (attr in attrs) {
+        if (hasProp(attrs, attr)) {
+          if (attr === 'class') elt.className = attrs.class
+          else if (attr === 'className') elt.className = attrs.className
+          else if (attr === 'style') setStyles(elt, attrs.style)
+          else elt.setAttribute(attr, attrs[attr])
+        }
+      }
+    }
+  } catch (error) {
+    console.error(error)
+  }
+
+  if (txtContent) addText(elt, txtContent)
+
+  return elt
+}
+
+/**
+ * Ajoute un élément html de type tag à parent
+ * @param {HTMLElement} parent
+ * @param {string} tag
+ * @param {Object=} attrs Les attributs
+ * @param {string=} content
+ * @returns {HTMLElement} L'élément ajouté
+ */
+export function addElement (parent, tag, attrs, content) {
+  const elt = create(tag, attrs, content)
+  parent.appendChild(elt)
+  return elt
+}

--- a/src/js/modules/messages.js
+++ b/src/js/modules/messages.js
@@ -1,81 +1,93 @@
+import { addElement, addText, get } from './dom'
 // Module regroupant les fonctions de gestions des erreurs.
 
-function divMessage (erreur) {
-// Construit le message d'erreur pour insertion dans la page.
-  if (erreur.niveau === 'erreur') {
-    return `<div id="affichageErreur" class="ui error message"><i id="fermerMessageErreur" class="close icon"></i>
-    <div class="header">
-      <i class="frown outline icon"></i> ${erreur.titre}
-    </div>
-      ${erreur.message}
-  </div>`
+const types = ['info', 'warning', 'error', 'positive']
+
+/**
+ * Ajoute le feedback dans container
+ * @param {HTMLElement} container
+ * @param {Object} erreur
+ * @param {string} [erreur.message]
+ * @param {string} [erreur.level]
+ * @param {string} [erreur.titre]
+ */
+export function addFeedback (container, { message = 'Une erreur est survenue', level = 'erreur', titre = 'Erreur interne' } = {}) {
+  if (!types.includes(level)) {
+    console.error(Error(`type de message inconnu : ${level}`))
+    level = 'error'
   }
-  if (erreur.niveau === 'warning') {
-    return `<div id="affichageErreur" class="ui warning message"><i id="fermerMessageErreur" class="close icon"></i>
-    <div class="header">
-      <i class="bullhorn icon"></i> ${erreur.titre}
-    </div>
-      ${erreur.message}
-  </div>`
+  const cssDiv = level === 'info' ? '' : level
+  const div = addElement(container, 'div', { className: `ui message ${cssDiv}` })
+  const cssIcon = level === 'error'
+    ? 'frown outline'
+    : (level === 'warning')
+        ? 'bullhorn'
+        : 'bell outline' // info
+  const iconClose = addElement(div, 'i', { className: 'close icon' })
+  iconClose.addEventListener('click', () => div.remove())
+  if (titre) {
+    const divTitre = addElement(div, 'div', { className: 'header' })
+    addElement(divTitre, 'i', { className: `${cssIcon} icon` })
+    addText(divTitre, titre)
   }
-  if (erreur.niveau === 'info') {
-    return `<div id="affichageErreur" class="ui message"><i id="fermerMessageErreur" class="close icon"></i>
-    <div class="header">
-      <i class="bell outline icon"></i> ${erreur.titre}
-    </div>
-      ${erreur.message}
-  </div>`
-  }
+  addText(div, message)
 }
 
 /**
-*
-* @param {code:'code de l'erreur',[exercice : 'identifiant de l'exercice']}
+* Affiche un message à l'utilisateur
 * @author Cédric GROLLEAU
+* @param {Object} datas
+* @param {string} datas.code codeExerciceInconnu|mg32load|scratchLoad
+* @param {string} [datas.exercice] à fournir si code vaut 'codeExerciceInconnu'
 */
-export function messageUtilisateur (erreur) {
-  let divErreur = ''
-  if (erreur.code === 'codeExerciceInconnu') {
-    divErreur = divMessage({
-      titre: 'le code de l\'exercice n\'est pas valide',
-      message: `L'identifiant ${erreur.exercice} ne correspond à aucun exercice MathALEA. <br> Ceci est peut-être dû à un lien incomplet ou obsolète. `,
-      niveau: 'erreur'
-    })
-  } else if (erreur.code === 'mg32load') {
-    divErreur = divMessage({
-      titre: 'Erreur de chargement du module mg32',
-      message: `Une erreur est survenue lors du chargement d'un module pour l'affichage de l'exercice. <br>
-        Essayez de rafraichir la page. <br> Si l'erreur persiste merci de contacter : <a href="mailto:contact@coopmaths.fr">contact@coopmaths.fr</a>`,
-      niveau: 'warning'
-    })
-  } else if (erreur.code === 'scratchLoad') {
-    divErreur = divMessage({
-      titre: 'Erreur de chargement du module scratch',
-      message: `Une erreur est survenue lors du chargement d'un module pour l'affichage de l'exercice. <br>
-        Essayez de rafraichir la page. <br> Si l'erreur persiste merci de contacter : <a href="mailto:contact@coopmaths.fr">contact@coopmaths.fr</a>`,
-      niveau: 'warning'
-    })
+export function messageUtilisateur ({ code, exercice }) {
+  const container = get('containerErreur')
+  switch (code) {
+    case 'codeExerciceInconnu':
+      addFeedback(container, {
+        titre: 'le code de l’exercice n’est pas valide',
+        message: `L'identifiant ${exercice} ne correspond à aucun exercice MathALEA. <br> Ceci est peut-être dû à un lien incomplet ou obsolète. `,
+        level: 'error'
+      })
+      break
+    case 'mg32load':
+      addFeedback(container, {
+        titre: 'Erreur de chargement du module mg32',
+        message: `Une erreur est survenue lors du chargement d'un module pour l'affichage de l'exercice. <br>
+          Essayez de rafraichir la page. <br> Si l'erreur persiste merci de contacter : <a href="mailto:contact@coopmaths.fr">contact@coopmaths.fr</a>`,
+        level: 'warning'
+      })
+      break
+    case 'scratchLoad':
+      addFeedback(container, {
+        titre: 'Erreur de chargement du module scratch',
+        message: `Une erreur est survenue lors du chargement d'un module pour l'affichage de l'exercice. <br>
+          Essayez de rafraichir la page. <br> Si l'erreur persiste merci de contacter : <a href="mailto:contact@coopmaths.fr">contact@coopmaths.fr</a>`,
+        level: 'warning'
+      })
+      break
+    default:
+      console.error(Error(`code ${code} non géré par messageUtilisateur`))
+      addFeedback(container, {
+        titre: 'Erreur interne',
+        message: `Une erreur est survenue.<br>
+          Essayez de rafraichir la page. <br> Si l'erreur persiste merci de contacter : <a href="mailto:contact@coopmaths.fr">contact@coopmaths.fr</a>`,
+        level: 'warning'
+      })
   }
-  document.getElementById('containerErreur').innerHTML = divErreur
-  document.getElementById('fermerMessageErreur').addEventListener('click', function () {
-    document.getElementById('affichageErreur').remove()
-  })
 }
 
 /**
- *
- * @param {id : 'id du div', texte: 'message', type:'error ou positive'}
+ * Ajoute un feedback (erreur ou encouragement)
+ * @param {Object} data
+ * @param {string} data.id id du div conteneur à utiliser
+ * @param {string} data.texte Le texte à afficher
+ * @param {string} data.type error|positive
  * @author Rémi ANGOT
  */
 export function messageFeedback ({ id, texte = '', type = 'error' } = {}) {
-  const typeMessage = type || 'error'
-  if (id && texte) {
-    const html = `<div id="messageFeedback${id}" class="ui ${typeMessage} message" style="width:400px"><i id="fermerFeedback${id}" class="close icon"></i>
-        ${texte}
-  </div>`
-    document.getElementById(id).innerHTML = html
-    document.getElementById(`fermerFeedback${id}`).addEventListener('click', function () {
-      document.getElementById(`messageFeedback${id}`).remove()
-    })
-  }
+  if (!id || !texte) return console.error(TypeError('arguments manquants'))
+  const container = get(id)
+  const div = addFeedback(container, { message: texte, level: type })
+  div.style.width = '400px'
 }


### PR DESCRIPTION
J'ai ajouté qq fcts pour manipuler le dom, et modifié un peu la façon de gérer les feedback (la fct prend un conteneur et ajoute les éléments dedans plutôt que de construire du html et le retourner, ça évite le couplage lié au id, et les collisions d'id)