### PR TITLE
bugfix 2L13 + ESLint outils.js

### DIFF
--- a/src/js/exercices/2e/2L13.js
+++ b/src/js/exercices/2e/2L13.js
@@ -207,7 +207,7 @@ export default function ExerciceInequation1 () {
           b = randint(1, 9)
           d = randint(b + 1, 15) // d sera plus grand que b pour que d-b>0
         }
-        texte = `$${rienSi1(a)}x${ecritureAlgebrique(b)}${texSymbole(symboleInegalite)}${rienSi1(c)}x${ecritureAlgebrique(d)}$`
+        texte = `$${rienSi1(a)}x${ecritureAlgebrique(b)}${texSymbole(symboleInegalite)} ${rienSi1(c)}x${ecritureAlgebrique(d)}$`
         texteCorr = texte + '<br>'
         if (this.correctionDetaillee) {
           if (c > 0) {

--- a/src/js/modules/outils.js
+++ b/src/js/modules/outils.js
@@ -2586,23 +2586,23 @@ export function texFraction (a, b) {
 
 /**
  * Retourne le code LateX correspondant à un symbole
- * @param {string} symbole 
+ * @param {string} symbole
  * @returns {string} string
  * @author Guillaume Valmont
  * @example texSymbole("≤") retourne "\\leq"
  */
 export function texSymbole (symbole) {
-  switch (symbole){
-    case "<":
-      return "<";
-    case ">":
-      return ">";
-    case "≤":
-      return "\\leq";
-    case "≥":
-      return "\\geq";
+  switch (symbole) {
+    case '<':
+      return '<'
+    case '>':
+      return '>'
+    case '≤':
+      return '\\leq'
+    case '≥':
+      return '\\geq'
     default:
-      return "symbole non connu par texSymbole()";
+      return 'symbole non connu par texSymbole()'
   }
 }
 


### PR DESCRIPTION
Lorsque `${rienSi1(c)}` était vide et que `${texSymbole(symboleInegalite)}` était `\\leq` ou `\\geq`, le `texSymbole` se mélangeait avec le `x` d'après et donnait par exemple un `\\geqx` ininterprétable.
Le fix consistait à ajouter un espace \*-\*