### PR TITLE
Bug Fix AMC : 

### DIFF
--- a/jsdoc/tutorials/guideInteractifAmc.md
+++ b/jsdoc/tutorials/guideInteractifAmc.md
@@ -18,12 +18,13 @@ Plusieurs attributs de la classe Exercice() sont nécessaires pour activer la po
 
   amcType peut prendre les valeurs suivantes :
 
-  1 : qcm avec une seule bonne réponse (évolution vers le bouton radio ?). Modèle : 6C10-2
-  2 : qcm avec possibilité de plusieures bonnes réponses. Modèle : 6N43-2
-  3 : question ouverte -> il n'y a pas d'interactivité l'affichage est classique par contre on peut l'exporter vers AMC en question ouverte. Modèle : 6C10-5
-  4 : réponse numérique à entrer dans un formulaire texte. AmcNumeriqueChoice (voire attribut reponse). Modèle : 6C10
-  5 : réponse identique au type 4 mais AMC ajoute une zone pour une réponse ouverte. Modèle : 3G30
-  6 : plusieures réponses numériques (plusieurs attributs reponse, reponse2,...). Modèle : 4C21
+  'qcmMono' : qcm avec une seule bonne réponse (évolution vers le bouton radio ?). Modèle : 6C10-2
+  'qcmMult' : qcm avec possibilité de plusieures bonnes réponses. Modèle : 6N43-2
+  'amcOpen' : question ouverte -> il n'y a pas d'interactivité l'affichage est classique par contre on peut l'exporter vers AMC en question ouverte. Modèle : 6C10-5
+  'amcNum' : réponse numérique à entrer dans un formulaire texte. AmcNumeriqueChoice (voire attribut reponse). Modèle : 6C10
+  'amcOpenNum' : réponse identique au type 4 mais AMC ajoute une zone pour une réponse ouverte. Modèle : 3G30
+  'AMCOpenNum✖︎2' : plusieures réponses numériques (plusieurs attributs reponse, reponse2,...). Modèle : 4C21
+  AMCOpenNum✖︎3 : Une réponse en plus ... 
   custom : Ces exercices ne sont pas prédéfinis, ils partagent le bouton de validation puis appellent la méthode correctionInteractive() définie dans l'exercice. Ils ne sont pas compatibles avec AMC
 
   # La variable this.autoCorrection
@@ -35,7 +36,7 @@ Plusieurs attributs de la classe Exercice() sont nécessaires pour activer la po
   ```
   Selon les types, l'objet s'adapte :
 
-  type 1 :
+  type 'qcmMono' :
   ```js
   this.autoCorrection[i] = {
       enonce: 'la question est posée ici',
@@ -61,9 +62,9 @@ Plusieurs attributs de la classe Exercice() sont nécessaires pour activer la po
   }
   ```
 
-type 2 : il est identique au type 1, à la différence près qu'il y aura peut-être plusieurs statut à true
+type 'qcmMult' : il est identique au type 1, à la différence près qu'il y aura peut-être plusieurs statut à true
 
-type 3 : (uniquement pour AMC) ici un exemple pour une exercice ne produisant qu'une question (il y aura autant d'objet que this.nbQuestion>1)
+type 'amcOpen' : (uniquement pour AMC) ici un exemple pour une exercice ne produisant qu'une question (il y aura autant d'objet que this.nbQuestion>1)
 
 ```js
   this.autoCorrection = [
@@ -80,7 +81,7 @@ type 3 : (uniquement pour AMC) ici un exemple pour une exercice ne produisant qu
     ]
 ```
  
-type 4 : Voici un élément type (la différence se situe dans l'attribut reponse)
+type 'amcNum' : Voici un élément type (la différence se situe dans l'attribut reponse)
 ```js
 this.autoCorrection[i] = {
         enonce: 'ici la question est posée',

--- a/src/js/exercices/CM/CM000.js
+++ b/src/js/exercices/CM/CM000.js
@@ -27,6 +27,7 @@ export default function TablesAdditionsSoustractions () {
   this.interactif = true
 
   this.nouvelleVersion = function () {
+    this.autoCorrection = []
     this.sup = parseInt(this.sup)
     this.sup2 = parseInt(this.sup2)
     this.listeQuestions = [] // Liste de questions
@@ -71,7 +72,7 @@ export default function TablesAdditionsSoustractions () {
     for (let i = 0, a, b, texte, texteCorr; i < this.nbQuestions; i++) {
       a = randint(2, this.sup)
       b = randint(2, this.sup)
-
+      this.autoCorrection[i] = {}
       switch (listeTypeDeQuestions[i]) {
         case 'addition':
           texte = `$${a} + ${b} = \\dotfill$`

--- a/src/js/modules/outils.js
+++ b/src/js/modules/outils.js
@@ -6878,7 +6878,9 @@ export function exportQcmAmc (exercice, idExo) {
         texQr += `\\element{${ref}}{\n `
         texQr += `\\begin{questionmultx}{question-${ref}-${lettreDepuisChiffre(idExo + 1)}-${id}} \n `
         texQr += `${autoCorrection[j].enonce} \n `
-        texQr += `\\explain{${autoCorrection[j].propositions[0].texte}}\n`
+        if (autoCorrection[j].propositions !== undefined) {
+          texQr += `\\explain{${autoCorrection[j].propositions[0].texte}}\n`
+        }
         texQr += `\\AMCnumericChoices{${autoCorrection[j].reponse.valeur}}{digits=${autoCorrection[j].reponse.param.digits},decimals=${autoCorrection[j].reponse.param.decimals},sign=${autoCorrection[j].reponse.param.signe},`
         if (autoCorrection[j].reponse.param.exposantNbChiffres !== undefined && autoCorrection[j].reponse.param.exposantNbChiffres !== 0) { // besoin d'un champ pour la puissance de 10. (notation scientifique)
           texQr += `exponent=${autoCorrection[j].reponse.param.exposantNbChiffres},exposign=${autoCorrection[j].reponse.param.exposantSigne},`
@@ -6920,7 +6922,9 @@ export function exportQcmAmc (exercice, idExo) {
         texQr += '\\begin{minipage}[b]{0.7 \\linewidth}\n'
         texQr += `\\begin{question}{question-${ref}-${lettreDepuisChiffre(idExo + 1)}-${id}a} \n `
         texQr += `${autoCorrection[j].enonce} \n `
-        texQr += `\\explain{${autoCorrection[j].propositions[0].texte}}\n`
+        if (autoCorrection[j].propositions !== undefined) {
+          texQr += `\\explain{${autoCorrection[j].propositions[0].texte}}\n`
+        }
         texQr += `\\notation{${autoCorrection[j].propositions[0].statut}}\n`
         // texQr += `\\AMCOpen{lines=${tabQCM[1][2]}}{\\mauvaise[NR]{NR}\\scoring{0}\\mauvaise[RR]{R}\\scoring{0.01}\\mauvaise[R]{R}\\scoring{0.33}\\mauvaise[V]{V}\\scoring{0.67}\\bonne[VV]{V}\\scoring{1}}\n`
         texQr += '\\end{question}\n\\end{minipage}\n'
@@ -6982,7 +6986,9 @@ export function exportQcmAmc (exercice, idExo) {
         texQr += '\\begin{minipage}[b]{0.7 \\linewidth}\n'
         texQr += `\\begin{question}{question-${ref}-${lettreDepuisChiffre(idExo + 1)}-${id}a} \n `
         texQr += `${autoCorrection[j].enonce} \n `
-        texQr += `\\explain{${autoCorrection[j].propositions[0].texte}}\n`
+        if (autoCorrection[j].propositions !== undefined) {
+          texQr += `\\explain{${autoCorrection[j].propositions[0].texte}}\n`
+        }
         texQr += `\\notation{${autoCorrection[j].propositions[0].statut}}\n`
         texQr += '\\end{question}\n\\end{minipage}\n'
         reponse = autoCorrection[j].reponse.valeur
@@ -7054,7 +7060,9 @@ export function exportQcmAmc (exercice, idExo) {
         texQr += '\\begin{minipage}[b]{0.4 \\linewidth}\n'
         texQr += `\\begin{question}{question-${ref}-${lettreDepuisChiffre(idExo + 1)}-${id}a} \n `
         texQr += `${autoCorrection[j].enonce} \n `
-        texQr += `\\explain{${autoCorrection[j].propositions[0].texte}}\n`
+        if (autoCorrection[j].propositions !== undefined) {
+          texQr += `\\explain{${autoCorrection[j].propositions[0].texte}}\n`
+        }
         texQr += `\\notation{${autoCorrection[j].propositions[0].statut}}\n`
         texQr += '\\end{question}\n\\end{minipage}\n'
         reponse = autoCorrection[j].reponse.valeur


### PR DESCRIPTION
Au cas où SetReponse est utilisée mais que propositions n'était pas défini, exportQcmAmc provoquait une erreur en allant chercher une valeur n'éxistant pas pour la correction. Initialement, autoCorrection[i].propositions[0].texte devrait contenir le texte de la correction pour la commande AMC \explain...