### PR TITLE
Règle provisoirement le bug des mauvais boutons de validation

### DIFF
--- a/src/js/mathalea.js
+++ b/src/js/mathalea.js
@@ -1131,9 +1131,9 @@ function miseAJourDeLaListeDesExercices (preview) {
           .then((module) => {
             if (!module) throw Error(`l'import de ${path} a réussi mais on ne récupère rien, il doit y avoir un oubli d'export`)
             listeObjetsExercice[i] = new module.default()
-            ;['titre', 'amcReady', 'amcType', 'interactifType', 'interactifReady'].forEach(p => {
+            /*  ;['titre', 'amcReady', 'amcType', 'interactifType', 'interactifReady'].forEach(p => {
               if (module[p] !== undefined) listeObjetsExercice[i][p] = module[p]
-            })
+            }) */
             if (dictionnaireDesExercices[id].sup !== undefined) {
               listeObjetsExercice[i].sup = dictionnaireDesExercices[id].sup
             }

--- a/src/js/mathalea.js
+++ b/src/js/mathalea.js
@@ -1131,9 +1131,9 @@ function miseAJourDeLaListeDesExercices (preview) {
           .then((module) => {
             if (!module) throw Error(`l'import de ${path} a réussi mais on ne récupère rien, il doit y avoir un oubli d'export`)
             listeObjetsExercice[i] = new module.default()
-            /*  ;['titre', 'amcReady', 'amcType', 'interactifType', 'interactifReady'].forEach(p => {
+            ;['titre', 'amcReady', 'amcType', 'interactifType', 'interactifReady'].forEach(p => {
               if (module[p] !== undefined) listeObjetsExercice[i][p] = module[p]
-            }) */
+            })
             if (dictionnaireDesExercices[id].sup !== undefined) {
               listeObjetsExercice[i].sup = dictionnaireDesExercices[id].sup
             }

--- a/src/js/modules/gestionInteractif.js
+++ b/src/js/modules/gestionInteractif.js
@@ -29,13 +29,14 @@ export function exerciceInteractif (exercice) {
  * @param {object} exercice
  */
 export function exerciceQcm (exercice) {
+  console.log('Dans ExerciceQcm : ', exercice.nbQuestions, exercice.titre, exercice.numeroExercice, exercice.id)
   document.addEventListener('exercicesAffiches', () => {
     // On active les checkbox
     $('.ui.checkbox').checkbox()
     // Couleur pour surligner les label avec une opacité de 50%
     const monRouge = 'rgba(217, 30, 24, 0.5)'
     const monVert = 'rgba(123, 239, 178, 0.5)'
-    const button = document.querySelector(`#btnValidationEx${exercice.numeroExercice}`)
+    const button = document.querySelector(`#btnValidationEx${exercice.numeroExercice}-${exercice.id}`)
     if (button) {
       button.addEventListener('click', event => {
         let nbQuestionsValidees = 0
@@ -194,8 +195,9 @@ export function elimineDoublons (propositions) { // fonction qui va éliminer le
  * @param {object} exercice
  */
 export function exerciceNumerique (exercice) {
+  console.log('Dans ExerciceNumerique : ', exercice.nbQuestions, exercice.titre, exercice.numeroExercice, exercice.id)
   document.addEventListener('exercicesAffiches', () => {
-    const button = document.querySelector(`#btnValidationEx${exercice.numeroExercice}`)
+    const button = document.querySelector(`#btnValidationEx${exercice.numeroExercice}-${exercice.id}`)
     if (button) {
       button.addEventListener('click', event => {
         let nbBonnesReponses = 0
@@ -239,7 +241,7 @@ export function exerciceCliqueFigure (exercice) {
       }
     }
     // Gestion de la correction
-    const button = document.querySelector(`#btnValidationEx${exercice.numeroExercice}`)
+    const button = document.querySelector(`#btnValidationEx${exercice.numeroExercice}-${exercice.id}`)
     if (button) {
       button.addEventListener('click', event => {
         let nbBonnesReponses = 0
@@ -366,7 +368,7 @@ export function setReponse (exercice, i, valeurs, { digits = 0, decimals = 0, si
  */
 export function exerciceCustom (exercice) {
   document.addEventListener('exercicesAffiches', () => {
-    const button = document.querySelector(`#btnValidationEx${exercice.numeroExercice}`)
+    const button = document.querySelector(`#btnValidationEx${exercice.numeroExercice}-${exercice.id}`)
     if (button) {
       button.addEventListener('click', event => {
         // Le get est non strict car on sait que l'élément n'existe pas à la première itération de l'exercice
@@ -395,7 +397,7 @@ export function exerciceCustom (exercice) {
 export function exerciceMathLive (exercice) {
   const engine = new ComputeEngine()
   document.addEventListener('exercicesAffiches', () => {
-    const button = document.querySelector(`#btnValidationEx${exercice.numeroExercice}`)
+    const button = document.querySelector(`#btnValidationEx${exercice.numeroExercice}-${exercice.id}`)
     if (button) {
       button.addEventListener('click', event => {
         let nbBonnesReponses = 0

--- a/src/js/modules/outils.js
+++ b/src/js/modules/outils.js
@@ -21,7 +21,7 @@ export function listeQuestionsToContenu (exercice) {
   if (context.isHtml) {
     exercice.contenu = htmlConsigne(exercice.consigne) + htmlParagraphe(exercice.introduction) + htmlEnumerate(exercice.listeQuestions, exercice.spacing)
     if (exercice.interactif) {
-      exercice.contenu += `<button class="ui button checkReponses" type="submit" style="margin-bottom: 20px; margin-top: 20px" id="btnValidationEx${exercice.numeroExercice}">Vérifier les réponses</button>`
+      exercice.contenu += `<button class="ui button checkReponses" type="submit" style="margin-bottom: 20px; margin-top: 20px" id="btnValidationEx${exercice.numeroExercice}-${exercice.id}">Vérifier les réponses</button>`
     }
     exercice.contenuCorrection = htmlParagraphe(exercice.consigneCorrection) + htmlEnumerate(exercice.listeCorrections, exercice.spacingCorr)
   } else {


### PR DESCRIPTION
En ajoutant l'id de l'exercice concerné par le bouton, on s'assure que le bouton est bien relié à la bonne fonction de vérification (qcm, numerique,...).
Cela ne règle pas le problème des handlers superflus qui s'accumulent.