### PR TITLE
Bug bouton can

### DIFF
--- a/src/js/mathalea.js
+++ b/src/js/mathalea.js
@@ -342,9 +342,11 @@ function miseAJourDuCode () {
   // Active ou désactive l'icone de la course aux nombres
   let tousLesExercicesSontInteractifs = true
   for (const exercice of listeObjetsExercice) {
-    if (!exercice.interactifReady && document.getElementById('btnCan')) {
+    if (!exercice.interactifReady) {
       tousLesExercicesSontInteractifs = false
-      document.getElementById('btnCan').classList.add('disabled')
+      if (document.getElementById('btnCan')) {
+        document.getElementById('btnCan').classList.add('disabled')
+      }
     }
   }
   if (document.getElementById('btnCan') !== null) {

--- a/src/js/mathalea.js
+++ b/src/js/mathalea.js
@@ -342,7 +342,7 @@ function miseAJourDuCode () {
   // Active ou désactive l'icone de la course aux nombres
   let tousLesExercicesSontInteractifs = true
   for (const exercice of listeObjetsExercice) {
-    if (!exercice.interactifReady) {
+    if (!exercice.interactifReady && document.getElementById('btnCan')) {
       tousLesExercicesSontInteractifs = false
       document.getElementById('btnCan').classList.add('disabled')
     }

--- a/src/js/mathalea.js
+++ b/src/js/mathalea.js
@@ -2000,10 +2000,11 @@ document.addEventListener('DOMContentLoaded', async () => {
     }
     document.getElementById('filtre').addEventListener('change', function () {
       // gestion du changement du select.
-      const regex = /'([?;&])filtre[^&;]*[;&]?'/
-      const query = window.location.search.replace(regex, '$1').replace(/&$/, '')
-      const filtre = document.getElementById('filtre').value
-      const url = (query.length > 2 ? query + '&' : '?') + (filtre !== 'tous' ? 'filtre=' + filtre : '')
+      const searchParams = new URLSearchParams(window.location.search);
+      const newFiltre = document.getElementById('filtre').value
+      searchParams.set('filtre',newFiltre)
+      const newParams = searchParams.toString()
+      const url = window.location.href.split('?')[0] + '?' + decodeURIComponent(newParams)
       let modeTableauActif = false // Gestion pour le mode tableau particulière pour gérer l'activation de "datatable"
       window.history.pushState('', '', url)
       if ($('#mode_choix_liste').is(':visible')) {


### PR DESCRIPTION
Dans la vue embed, il n'y a pas la bouton CAN ajout d'un test avant de le mettre à "disabled" quand les exercices ne sont pas interactifs.
J'en ai profité pour corriger le bug signalé sur les filtres