### PR TITLE
prévient Anki d'augmenter la taille de l'embed en cas d'animation IEP

### DIFF
--- a/src/js/mathalea.js
+++ b/src/js/mathalea.js
@@ -232,6 +232,9 @@ async function gestionModules (isdiaporama, listeObjetsExercice) {
       const xml = window.listeScriptsIep[id]
       await loadIep(element, xml)
     }
+    // On prévient Anki qu'il faut une plus grande fenêtre
+    const IEPAffiche = new Event('IEPAffiche', { bubbles: true })
+    document.dispatchEvent(IEPAffiche)
   }
 }
 

--- a/src/js/modules/initDom.js
+++ b/src/js/modules/initDom.js
@@ -171,10 +171,16 @@ export async function initDom () {
     }
     // Le titre de l'exercice ne peut être masqué qu'après l'affichage
     document.addEventListener('exercicesAffiches', masqueTitreExerciceEtEspaces)
+    let hauteurIEP = 0; let hauteurCorrection = 0
+    document.addEventListener('IEPAffiche', () => {
+      // Envoi des informations à Anki
+      hauteurIEP = window.document.body.scrollHeight + window.document.body.scrollWidth * 0.75 + 60
+      window.parent.postMessage({ hauteur: Math.max(hauteurCorrection, hauteurIEP), reponse: 'A_COMPLETER' }, '*')
+    })
     document.addEventListener('exercicesAffiches', () => {
       // Envoi des informations à Anki
-      const hauteur = window.document.body.scrollHeight
-      window.parent.postMessage({ hauteur: hauteur, reponse: 'A_COMPLETER' }, '*')
+      hauteurCorrection = window.document.body.scrollHeight
+      window.parent.postMessage({ hauteur: Math.max(hauteurCorrection, hauteurIEP), reponse: 'A_COMPLETER' }, '*')
     })
   } else if (vue === 'eval') {
     setOutputHtml()


### PR DESCRIPTION
Par contre je n'ai pas trouvé comment récupérer la hauteur de l'animation IEP.
J'ai calculé qu'elle faisait environ 73% de la largeur et ai donc ajouté 75% de la largeur + 60px (pour le bouton et pour avoir une marge) à la hauteur