### PR TITLE
fix; _Tables_de_multiplications : valeurs résiduelles dans this.autoCorrection

### DIFF
--- a/src/js/exercices/6e/_Tables_de_multiplications.js
+++ b/src/js/exercices/6e/_Tables_de_multiplications.js
@@ -26,6 +26,7 @@ export default function TablesDeMultiplications (tablesParDefaut = '2-3-4-5-6-7-
     this.sup2 = parseInt(this.sup2)
     this.listeQuestions = [] // Liste de questions
     this.listeCorrections = [] // Liste de questions corrigées
+    this.autoCorrection = []
     if (!this.sup) {
       // Si aucune table n'est saisie
       this.sup = '2-3-4-5-6-7-8-9'


### PR DESCRIPTION
En mode AMC, quand on changeait le paramètre s2 de 2 (à trou) à 3 (mélange), on avait des réponses attendues qui correspondaient à l'autre facteur voir au résultat quand c'était une question à trou.
un this.autoCorrection = [] en début de this.nouvelleVersion semble régler le problème.
Il se pourrait que nombre d'exercices soient concernés par cette erreur !
Point de vigilance !