### PR TITLE
Corrige le clavier mathématique

### DIFF
--- a/src/css/style_mathalea.css
+++ b/src/css/style_mathalea.css
@@ -597,12 +597,13 @@ a.lien_id_exercice.exerciceactif {
 
 }
 
-div.ML__keyboard.is-visible {
+body.exMoodle div.ML__keyboard.is-visible {
 	position: absolute;
 	top: var(--keyboard-position);
+  height: revert;
 }
 
-div.ML__keyboard.is-visible .ML__keyboard--plate {
+body.exMoodle div.ML__keyboard.is-visible .ML__keyboard--plate {
 	position: static;
 	transform: none;
 }

--- a/src/js/modules/loaders.js
+++ b/src/js/modules/loaders.js
@@ -169,6 +169,7 @@ export async function loadMathLive () {
 
       // Evite les problèmes de positionnement du clavier mathématique dans les iframes
       if (context.vue === 'exMoodle') {
+        document.body.classList.add('exMoodle')
         const events = ['focus', 'input']
         events.forEach(e => {
           mf.addEventListener(e, () => {


### PR DESCRIPTION
- Il ne fonctionnait plus hors intégration moodle
- Il laissait un grand espace à la fin de la page lors de son ouverture dans l'intégration moodle