### PR TITLE
fix: outilsMathjs

### DIFF
--- a/src/js/exercices/beta/betaEquations.js
+++ b/src/js/exercices/beta/betaEquations.js
@@ -61,7 +61,7 @@ function schemaBarre () {
 export default function equationsProgression () {
   Exercice.call(this)
   const formulaire = []
-  for (let i = 0; i < 119; i++) formulaire.push(`${i}`)
+  for (let i = 0; i < 120; i++) formulaire.push(`${i}`)
   this.nbQuestions = 0
   this.besoinFormulaireNumerique = [
     'Type de question', this.nbQuestions, formulaire.join('\n')
@@ -1174,6 +1174,14 @@ export default function equationsProgression () {
           exercice.texte = `(Problème à régler : signe de la multiplication dans les calculs)
           <br>
           Calculer : $${exercice.printExpression}$`
+          exercice.texteCorr = this.correctionDetaillee ? '<br>' + exercice.texteCorr : `$${exercice.printExpression}=${exercice.printResult}$`
+          break
+        }
+        case 119 : {
+          exercice = resoudre('5*x+2=0')
+          exercice.texte = `
+          <br>
+          Résoudre : $${exercice.printExpression}$`
           exercice.texteCorr = this.correctionDetaillee ? '<br>' + exercice.texteCorr : `$${exercice.printExpression}=${exercice.printResult}$`
           break
         }

--- a/src/js/exercices/beta/betaModele50_Mathsteps.js
+++ b/src/js/exercices/beta/betaModele50_Mathsteps.js
@@ -121,10 +121,14 @@ export default function NomExercice () {
           const variables = aleaVariables(
             {
               a: true,
-              b: true
+              b: true,
+              c: true,
+              d: true,
+              test: 'a!=c'
             }
           )
-          exercice = resoudre('9*x+a=6*x+b', { variables: variables, color: 'blue', comment: true })
+          // Toutes les étapes sont détaillées avec le paramètre reduceSteps: false
+          exercice = resoudre('a*x+b=c*x+d', { reduceSteps: false, variables: variables, color: 'blue', comment: true })
           exercice.texte = `Résoudre : $${exercice.equation}$`
           exercice.texteCorr = `
           <br>


### PR DESCRIPTION
- fix : resoudre() corriger le problème de la disparition d'une étape dans le cas particulier ax+b=0
- feat : resoudre() Ajout d'un paramètre pour montrer des étapes masquées
- feat : toTex() Supprimer les parenthèses à la racine du noeud