### PR TITLE
fix texNombre

### DIFF
--- a/src/js/modules/outils.js
+++ b/src/js/modules/outils.js
@@ -2770,7 +2770,7 @@ function afficherNombre (nb, precision, fonction) {
   // si nb n'est pas un nombre, on le retourne tel quel, on ne fait rien.
   if (isNaN(nb)) return nb
   // si c'en est un, on le formate.
-  const nbChiffresPartieEntiere = Math.abs(nb) < 1 ? 0 : Math.abs(nb).toFixed(0).length
+  const nbChiffresPartieEntiere = Math.abs(nb) < 1 ? 1 : Math.abs(nb).toFixed(0).length
   if (Number.isInteger(nb)) precision = 0
   else {
     if (typeof precision !== 'number') { // Si precision n'est pas un nombre, on le remplace par la valeur max acceptable


### PR DESCRIPTION
texNombre(0) affichait '0 e + 0' dans le 6S11 à la sortie de math.format(0,{notation: 'auto', lowerExp: 0, upperExp: 0, precision: 0})

Solution trouvée : donner 1 chiffre dans la partie entière des nombres dont la valeur absolue est plus petite que 1.