### PR TITLE
fix: labelPoint()

### DIFF
--- a/src/js/modules/2d.js
+++ b/src/js/modules/2d.js
@@ -635,6 +635,9 @@ function LabelPoint (...points) {
         case 'above':
           code += texteParPosition(A.nom, x, y + 10 / coeff, 'milieu', this.color, 1, 'middle', true).svg(coeff) + '\n'
           break
+        case 'above left':
+          code += texteParPosition(A.nom, x - 10 / coeff, y + 10 / coeff, 'milieu', this.color, 1, 'middle', true).svg(coeff) + '\n'
+          break
         case 'above right':
           code += texteParPosition(A.nom, x + 10 / coeff, y + 10 / coeff, 'milieu', this.color, 1, 'middle', true).svg(coeff) + '\n'
           break
@@ -645,7 +648,7 @@ function LabelPoint (...points) {
           code += texteParPosition(A.nom, x + 10 / coeff, y - 10 / coeff, 'milieu', this.color, 1, 'middle', true).svg(coeff) + '\n'
           break
         default:
-          code += texteParPosition(A.nom, x - 10 / coeff, y + 10 / coeff, 'milieu', this.color, 1, 'middle', true).svg(coeff) + '\n'
+          code += texteParPosition(A.nom, x, y, 'milieu', this.color, 1, 'middle', true).svg(coeff) + '\n'
           break
       }
     }


### PR DESCRIPTION
Dans l'export SVG de labelPoint() il y a un oubli pour la prise en charge de la position 'above left' et un oubli de la prise en charge de la position 'center' (par défaut c'était 'above left' qui était sélectionné).