### PR TITLE
fix: sp() fonctionne maintenant aussi bien en mode math qu'en mode texte.

### DIFF
--- a/src/js/exercices/4e/4I1-2.js
+++ b/src/js/exercices/4e/4I1-2.js
@@ -12,7 +12,7 @@ export const amcType = 'qcmMono'
 export const titre = 'Tortue Scratch avec répétitions'
 
 /**
- * Référence : 4I1-1
+ * Référence : 4I2
  * Publié le : 29/06/2021
  * @author Jean-Claude Lhote
  * Géné

--- a/src/js/mathalea.js
+++ b/src/js/mathalea.js
@@ -204,6 +204,7 @@ async function gestionModules (listeObjetsExercice) {
         { left: '\\[', right: '\\]', display: true },
         { left: '$', right: '$', display: false }
       ],
+      preProcess: (chaine) => chaine.replaceAll(String.fromCharCode(160), '\\,'),
       throwOnError: true,
       errorColor: '#CC0000',
       strict: 'warn',

--- a/src/js/modules/outils.js
+++ b/src/js/modules/outils.js
@@ -2715,7 +2715,7 @@ export function sp (nb = 1) {
   let s = ''
   for (let i = 0; i < nb; i++) {
     if (context.isHtml) s += '&nbsp;'
-    else s += '~'
+    else s += '\\,'
   }
   return s
 }


### PR DESCRIPTION
la fonction renderMathInElement en charge d'afficher en html les formules latex digérait très mal les &nbsp introduits par sp() en context.isHtml.
C'est maintenant réglé avec une fonction preProcess.