### PR TITLE
feat: texNombre(nb, n, true) et stringNombre(nb,n,true) force n chiffres après la virgule

### DIFF
--- a/src/js/modules/outils.js
+++ b/src/js/modules/outils.js
@@ -2518,10 +2518,11 @@ export function numberFormat (nb) {
  * @author Guillaume Valmont
  * @param {number} nb nombre à afficher
  * @param {number} precision nombre de décimales demandé
+ * @param {boolean} force true pour forcer à precision chiffres (ajout de zéros éventuels). false par défaut pour supprimer les zéros non significatifs.
  * @returns string avec le nombre dans le format français à mettre entre des $ $
  */
-export function texNombre (nb, precision = 8) {
-  const result = afficherNombre(nb, precision, 'texNombre')
+export function texNombre (nb, precision = 8, force = false) {
+  const result = afficherNombre(nb, precision, 'texNombre', force)
   return result.replace(',', '{,}').replace(/\s+/g, '\\,')
 }
 
@@ -2720,11 +2721,11 @@ export const insertCharInString = (string, index, char) => string.substring(0, i
  * @author Guillaume Valmont
  * @param {number} nb nombre à afficher
  * @param {number} precision nombre de décimales demandé
- * @param {boolean} notifier true pour envoyer un message à bugsnag pour prévenir qu'il y a trop de chiffres
+ * @param {boolean} force true pour forcer à precision chiffres (ajout de zéros éventuels). false par défaut pour supprimer les zéros non significatifs.
  * @returns string avec le nombre dans le format français à placer hors des $ $
  */
-export function stringNombre (nb, precision = 8) {
-  return afficherNombre(nb, precision, 'stringNombre')
+export function stringNombre (nb, precision = 8, force = false) {
+  return afficherNombre(nb, precision, 'stringNombre', force)
 }
 /**
  * Fonction auxiliaire aux fonctions stringNombre et texNombre
@@ -2736,7 +2737,7 @@ export function stringNombre (nb, precision = 8) {
  * @param {number} precision nombre de décimales demandé
  * @param {string} fonction nom de la fonction qui appelle afficherNombre (texNombre ou stringNombre) -> sert pour le message envoyé à bugsnag
  */
-function afficherNombre (nb, precision, fonction) {
+function afficherNombre (nb, precision, fonction, force = false) {
   /**
    * Fonction auxiliaire de stringNombre pour une meilleure lisibilité
    * Elle renvoie un nombre dans le format français (avec virgule et des espaces pour séparer les classes dans la partie entière et la partie décimale)
@@ -2749,7 +2750,20 @@ function afficherNombre (nb, precision, fonction) {
   function insereEspacesNombre (nb, maximumSignificantDigits = 15, fonction) {
     if (Number(nb) === 0) return '0'
     // let nombre = math.format(nb, { notation: 'fixed', lowerExp: -precision, upperExp: precision, precision: precision }).replace('.', ',')
-    let nombre = Intl.NumberFormat('fr-FR', { maximumSignificantDigits }).format(nb)
+    let nombre
+    if (Math.abs(nb < 1)) {
+      if (force) {
+        nombre = Intl.NumberFormat('fr-FR', { maximumFractionDigits: maximumSignificantDigits, minimumFractionDigits: maximumSignificantDigits }).format(nb)
+      } else {
+        nombre = Intl.NumberFormat('fr-FR', { maximumFractionDigits: maximumSignificantDigits }).format(nb)
+      }
+    } else {
+      if (force) {
+        nombre = Intl.NumberFormat('fr-FR', { maximumSignificantDigits, minimumSignificantDigits: maximumSignificantDigits }).format(nb)
+      } else {
+        nombre = Intl.NumberFormat('fr-FR', { maximumSignificantDigits }).format(nb)
+      }
+    }
     // console.log('précision : ', precision, 'nb : ', nb, 'nombre : ', nombre)
     const rangVirgule = nombre.indexOf(',')
     let partieEntiere = ''
@@ -2792,12 +2806,13 @@ function afficherNombre (nb, precision, fonction) {
       precision = 0
     }
   }
+
   const maximumSignificantDigits = nbChiffresPartieEntiere + precision
   if (maximumSignificantDigits > 15) { // au delà de 15 chiffres significatifs, on risque des erreurs d'arrondit
     window.notify(fonction + ' : Trop de chiffres', { nb, precision })
-    return insereEspacesNombre(nb, 15, fonction)
+    return insereEspacesNombre(nb, 15, fonction, force)
   } else {
-    return insereEspacesNombre(nb, maximumSignificantDigits, fonction)
+    return insereEspacesNombre(nb, maximumSignificantDigits, fonction, force)
   }
 }
 /**


### PR DESCRIPTION
Ajout de zéros non significatifs (par exemple pour des prix).
texNombre(nb, n) continue de fonctionner en affichant au plus n chiffres après la virgule. (le troisième paramètre est false par défaut).