### PR TITLE
fix: Blindage de QuestionMathLive toutes les fractions.

### DIFF
--- a/src/js/modules/interactif/questionMathLive.js
+++ b/src/js/modules/interactif/questionMathLive.js
@@ -105,7 +105,7 @@ export function verifQuestionMathLive (exercice, i) {
         } else {
           saisieParsee = parse(saisie)
         }
-        if (saisieParsee) {
+        if (Array.isArray(saisieParsee)) {
           if (saisieParsee[0] === 'Negate') {
             signeF = -1
             saisieParsee = saisieParsee[1].slice()
@@ -130,7 +130,7 @@ export function verifQuestionMathLive (exercice, i) {
           } else {
             saisieParsee = parse(saisie)
           }
-          if (saisieParsee) {
+          if (Array.isArray(saisieParsee)) {
             if (saisieParsee[0] === 'Negate') {
               signeF = -1
               saisieParsee = saisieParsee[1].slice()
@@ -164,7 +164,7 @@ export function verifQuestionMathLive (exercice, i) {
         } else {
           saisieParsee = parse(saisie)
         }
-        if (saisieParsee) {
+        if (Array.isArray(saisieParsee)) {
           if (saisieParsee[0] === 'Negate') {
             signeF = -1
             saisieParsee = saisieParsee[1].slice()


### PR DESCRIPTION
Un bug se produisait quand l'utilisateur saisissait une lettre ou quelque chose de différent d'un nombre ou d'une fraction.