### PR TITLE
fix: calcul(nombre) renvoie 6 décimales maxi par défaut

### DIFF
--- a/src/js/modules/outils.js
+++ b/src/js/modules/outils.js
@@ -1743,7 +1743,7 @@ export function calcul (x, arrondir = 6) {
     window.notify('Calcul : Reçoit une chaine de caractère et pas un nombre', { x })
     return parseFloat(evaluate(x).toFixed(arrondir))
   } else {
-    if (egalOuApprox(x, arrondir) !== '=') window.notify('calcul : arrondir semble avoir tronqué des décimales', { x, arrondir })
+    if (!egal(x, arrondi(x, precision), 10 ** (-precision - 1))) window.notify('calcul : arrondir semble avoir tronqué des décimales', { x, arrondir })
     return parseFloat(x.toFixed(arrondir))
   }
 }

--- a/src/js/modules/outils.js
+++ b/src/js/modules/outils.js
@@ -1738,10 +1738,10 @@ export function xcas (expression) {
 * Le 2e argument facultatif permet de préciser l'arrondi souhaité
 * @author Rémi Angot
 */
-export function calcul (x, arrondir = 13) {
+export function calcul (x, arrondir = 6) {
   if (typeof x === 'string') {
     window.notify('Calcul : Reçoit une chaine de caractère et pas un nombre', { x })
-    return parseFloat(evaluate(x).toFixed(arrondir === false ? 13 : arrondir))
+    return parseFloat(evaluate(x).toFixed(arrondir))
   } else {
     return parseFloat(x.toFixed(arrondir))
   }
@@ -5140,7 +5140,7 @@ export function nombreEnLettres (nb, type = 1) {
   if (estentier(nb)) return partieEntiereEnLettres(nb)
   else {
     partieEntiere = Math.floor(nb)
-    partieDecimale = calcul(nb - partieEntiere, 9)
+    partieDecimale = calcul(nb - partieEntiere, 3)
     nbDec = partieDecimale.toString().replace(/\d*\./, '').length
     partieDecimale = calcul(partieDecimale * 10 ** nbDec)
 

--- a/src/js/modules/outils.js
+++ b/src/js/modules/outils.js
@@ -1743,6 +1743,7 @@ export function calcul (x, arrondir = 6) {
     window.notify('Calcul : Reçoit une chaine de caractère et pas un nombre', { x })
     return parseFloat(evaluate(x).toFixed(arrondir))
   } else {
+    if (egalOuApprox(x, arrondir) !== '=') window.notify('calcul : arrondir semble avoir tronqué des décimales', { x, arrondir })
     return parseFloat(x.toFixed(arrondir))
   }
 }

--- a/src/js/modules/outils.js
+++ b/src/js/modules/outils.js
@@ -1743,7 +1743,7 @@ export function calcul (x, arrondir = 6) {
     window.notify('Calcul : Reçoit une chaine de caractère et pas un nombre', { x })
     return parseFloat(evaluate(x).toFixed(arrondir))
   } else {
-    if (!egal(x, arrondi(x, precision), 10 ** (-precision - 1))) window.notify('calcul : arrondir semble avoir tronqué des décimales', { x, arrondir })
+    if (!egal(x, arrondi(x, arrondir), 10 ** (-arrondir - 1))) window.notify('calcul : arrondir semble avoir tronqué des décimales', { x, arrondir })
     return parseFloat(x.toFixed(arrondir))
   }
 }


### PR DESCRIPTION
Pour une plus grande précision, il faut ajouter un paramètre : calcul(nombre, 12) par exemple.