### PR TITLE
fix: suppression de fonctions inutiles

### DIFF
--- a/src/assets/m2d/affinite.m2d
+++ b/src/assets/m2d/affinite.m2d
@@ -3,5 +3,5 @@ let A = point(7,3,'A')
 let d = droite(C,A) // On place les points C et A e on définit la droite(CA)
 let p = carre(C,A) // Le carré direct de sommets C puis A
 let q = affiniteOrtho(p,d,0.5) // q est le carré "applati" par l'affinité
-let r = polygoneRegulierIndirect(C,A,6) // L'hexagone régulier indirect de sommets C puis A
+let r = polygoneRegulier(A, C, 6) // L'hexagone régulier direct de sommets A puis C
 let s = affiniteOrtho(r,d,0.8) // sa version applatie par l'affinité de rapport 0.8

--- a/src/assets/m2d/transformations_animees.m2d
+++ b/src/assets/m2d/transformations_animees.m2d
@@ -3,7 +3,7 @@ let A = point(7,3,'A')
 let B = homothetie(A,C,3)
 let D = milieu(A,C)
 let d = droite(C,A) // On place les points C et A e on définit la droite(CA)
-let r = polygoneRegulierIndirect(C,A,6) // L'hexagone régulier indirect de sommets C puis A
+let r = polygoneRegulier(A,C,6) // L'hexagone régulier direct de sommets A puis C
 let t = rotation(r,D,180)
 let s = affiniteOrtho(r,d,0.001)
 affiniteOrthoAnimee(r,d,0.001) // sa version applatie 

--- a/src/js/modules/2d.js
+++ b/src/js/modules/2d.js
@@ -396,7 +396,7 @@ function TracePoint (...points) {
         } else if (this.style === '#') {
           p1 = point(A.x - this.tailleTikz, A.y - this.tailleTikz)
           p2 = point(A.x + this.tailleTikz, A.y - this.tailleTikz)
-          c = carreIndirect(p1, p2, this.color)
+          c = carre(p2, p1, this.color)
           c.epaisseur = this.epaisseur
           c.opacite = this.opacite
           c.couleurDeRemplissage = this.color
@@ -2469,6 +2469,7 @@ export function renommePolygone (p, noms) {
 
 /**
  * Trace le polygone régulier direct à n côtés qui a pour côté [AB]
+ * Pour tracer le polygone régulier indirect de côté [AB], on iversera A et B
  * @param {Point} A
  * @param {Point} B
  * @param {integer} n Nombre de côtés
@@ -2488,24 +2489,8 @@ export function polygoneRegulier (A, B, n, color = 'black') {
 }
 
 /**
- * polygoneRegulierIndirect(A,B,n) //Trace le polygone régulier indirect à n côtés qui a pour côté [AB]
- *
- * @author Rémi Angot
- */
-export function polygoneRegulierIndirect (A, B, n, color = 'black') {
-  const listePoints = [A, B]
-  for (let i = 1; i < n - 1; i++) {
-    listePoints[i + 1] = rotation(
-      listePoints[i - 1],
-      listePoints[i],
-      180 - 360 / n
-    )
-  }
-  return polygone(listePoints, color)
-}
-
-/**
  * Trace en 'color' le carré direct qui a pour côté [AB].
+ * Pour faire un carré Indirect de côté [AB], on inversera A et B.
  * @param {Point} A
  * @param {Point} B
  * @param {string} color facultatif
@@ -2513,13 +2498,6 @@ export function polygoneRegulierIndirect (A, B, n, color = 'black') {
  */
 export function carre (A, B, color) {
   return polygoneRegulier(A, B, 4, color)
-}
-
-/**
- * carreIndirect(A,B) //Trace le carré indirect qui a pour côté [AB]
- */
-export function carreIndirect (A, B, color) {
-  return polygoneRegulierIndirect(A, B, 4, color)
 }
 
 function CodageCarre (c, color = 'black', mark = '×') {
@@ -11526,7 +11504,7 @@ function Pavage () {
             P11 = rotation(P2, B, 60)
             P12 = rotation(P6, A, -60)
             P3 = polygoneRegulier(A, C, 4)
-            P4 = polygoneRegulierIndirect(B, C, 4)
+            P4 = polygoneRegulier(C, B, 4)
             P5 = rotation(P4, B, -150)
             P8 = rotation(P3, A, 150)
 
@@ -11622,10 +11600,10 @@ function Pavage () {
           for (let j = 0; j < Nx; j++) {
             C = rotation(A, B, -135)
             P1 = polygoneRegulier(A, B, 8)
-            P2 = polygoneRegulierIndirect(A, B, 8)
+            P2 = polygoneRegulier(B, A, 8)
             P3 = translation(P1, v)
             P4 = translation(P2, v)
-            P5 = polygoneRegulierIndirect(B, C, 4)
+            P5 = polygoneRegulier(C, B, 4)
             P6 = translation(P5, v)
             P7 = translation(P5, w)
             P8 = translation(P6, w)

--- a/src/js/modules/2d.js
+++ b/src/js/modules/2d.js
@@ -1,8 +1,9 @@
 import { calcul, arrondi, egal, randint, choice, rangeMinMax, unSiPositifMoinsUnSinon, lettreDepuisChiffre, nombreAvecEspace, stringNombre, premierMultipleSuperieur, premierMultipleInferieur, inferieurouegal, numberFormat, nombreDeChiffresDe, superieurouegal } from './outils.js'
 import { radians } from './fonctionsMaths.js'
 import { context } from './context.js'
-import { fraction, max, ceil, isNumeric } from 'mathjs'
+import { fraction, max, ceil, isNumeric, Fraction } from 'mathjs'
 import earcut from 'earcut'
+import FractionX from './FractionEtendue.js'
 
 /*
   MathALEA2D
@@ -6240,6 +6241,8 @@ function AxeY (
   ytick = ystep,
   titre = ''
 ) {
+  if (!(ystep instanceof Fraction || ystep instanceof FractionX)) ystep = fraction(ystep)
+  if (!(ytick instanceof Fraction || ytick instanceof FractionX)) ytick = fraction(ytick)
   ObjetMathalea2D.call(this)
   const objets = []
   objets.push(texteParPoint(titre, point(xmin - thick - 0.1, ymax), 'gauche', color))
@@ -6356,7 +6359,7 @@ function LabelY (
   ) {
     objets.push(
       texteParPoint(
-        y * coeff,
+        stringNombre(y * coeff, 3),
         point(pos, y),
         'gauche',
         color, 1, 'middle', true


### PR DESCRIPTION
carreIndirect(A,B) est supprimé car équivalent à carre(B,A)
polygoneRegulierIndirect(A,B,n) supprimé car équivalent à polygoneRegulier(B,A,n)