### PR TITLE
feat: contraindreValeur acceptant les nombres sous forme de string

### DIFF
--- a/src/js/modules/outils.js
+++ b/src/js/modules/outils.js
@@ -205,7 +205,7 @@ export function centrage (texte) {
  * @param {number} defaut valeur par défaut si non entier
  */
 export function contraindreValeur (min, max, valeur, defaut) {
-  return !(isNaN(valeur)) ? (valeur < min) ? min : (valeur > max) ? max : Number(valeur) : defaut
+  return (Number(valeur) < min) ? min : (Number(valeur) > max) ? max : defaut
 }
 
 /** Retourne un nombre décimal entre a et b, sans être trop près de a et de b


### PR DESCRIPTION
contraindreValeur(1, 8, '4', 2) retournait 2, avec cette modification, ça retournerait 4