### PR TITLE
fix: 1N11 utilisait ecritureAlgebrique() et ecritureParentheseSiNegatif() sur des miseEnEvidence() (string)

### DIFF
--- a/src/js/exercices/1e/1N11.js
+++ b/src/js/exercices/1e/1N11.js
@@ -39,7 +39,7 @@ export default function TermeDUneSuiteDefinieParRecurrence () {
           texteCorr = `On calcule successivent les termes jusqu'à obtenir $u_{${k}}$ :`
           for (let indice = 0; indice < k; indice++) {
             texteCorr += `<br> $u_{${indice + 1}} = ${miseEnEvidence('u_{' + indice + '}', arcenciel(indice, true))} ${ecritureAlgebrique(a)} = 
-              ${miseEnEvidence(u, arcenciel(indice, true))} + ${a} = ${miseEnEvidence(u + a, arcenciel(indice + 1, true))}$`
+              ${miseEnEvidence(u, arcenciel(indice, true))} ${ecritureAlgebrique(a)} = ${miseEnEvidence(u + a, arcenciel(indice + 1, true))}$`
             u = u + a
           }
           break
@@ -74,7 +74,7 @@ export default function TermeDUneSuiteDefinieParRecurrence () {
           texteCorr = `On calcule successivent les termes jusqu'à obtenir $u_${k}$ :`
           for (let indice = 0; indice < k; indice++) {
             texteCorr += `<br> $u_{${indice + 1}} = ${a}\\times ${miseEnEvidence('u_{' + indice + '}', arcenciel(indice, true))} ${ecritureAlgebrique(b)}=`
-            texteCorr += `${a} \\times ${ecritureParentheseSiNegatif(miseEnEvidence(u, arcenciel(indice, true)))} ${ecritureAlgebrique(b)} = 
+            texteCorr += `${a} \\times ${miseEnEvidence(ecritureParentheseSiNegatif(u), arcenciel(indice, true))} ${ecritureAlgebrique(b)} = 
             ${miseEnEvidence(a * u + b, arcenciel(indice + 1, true))}$`
             u = u * a + b
           }
@@ -93,7 +93,7 @@ export default function TermeDUneSuiteDefinieParRecurrence () {
           texteCorr = `On calcule successivent les termes jusqu'à obtenir $u_${k}$ :`
           for (let indice = 0; indice < k; indice++) {
             texteCorr += `<br> $u_{${indice + 1}} = ${a} ${signe(b)} (${miseEnEvidence('u_{' + indice + '}', arcenciel(indice, true))})^2=`
-            texteCorr += `${a} ${signe(b)} ${ecritureParentheseSiNegatif(miseEnEvidence(u, arcenciel(indice, true)))}^2 = 
+            texteCorr += `${a} ${signe(b)} ${miseEnEvidence(ecritureParentheseSiNegatif(u), arcenciel(indice, true))}^2 = 
               ${miseEnEvidence(texNombre(a + b * u * u), arcenciel(indice + 1, true))}$`
             u = a + b * u * u
           }

--- a/src/js/firstLoaded.js
+++ b/src/js/firstLoaded.js
@@ -2,14 +2,16 @@
 import Bugsnag from '@bugsnag/js'
 import { tropDeChiffres } from './modules/outils'
 window.notify = function notify (error, metadatas) {
-  if (typeof error === 'string') error = Error(error)
+  if (typeof error === 'string') {
+    if (error.includes(tropDeChiffres) && !window.Bugsnag) {
+      alert(error + '\nIl y a un risque d\'erreur d\'approximation (la limite est de 15 chiffres significatifs)\nnb : ' + metadatas.nb + '\nprecision (= nombre de décimales demandé) : ' + metadatas.precision)
+    }
+    error = Error(error)
+  }
   if (window.Bugsnag) {
     if (metadatas) Bugsnag.addMetadata('ajouts', metadatas)
     Bugsnag.notify(error)
   } else {
-    if (error.includes(tropDeChiffres)) {
-      alert(error + '\nIl y a un risque d\'erreur d\'approximation (la limite est de 15 chiffres significatifs)\nnb : ' + metadatas.nb + '\nprecision (= nombre de décimales demandé) : ' + metadatas.precision)
-    }
     console.error('message qui aurait été envoyé à bugsnag s\'il avait été configuré', error)
     if (metadatas) console.log('avec les metadatas', metadatas)
   }


### PR DESCRIPTION
Fix: window.notify() : c'est pas bien de changer le type d'une variable en cours de fonction...