### PR TITLE
chore: On alloue plus de RAM à webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "prepare": "husky install",
-    "start": "webpack serve",
+    "start": "NODE_OPTIONS='--max-old-space-size=4096' webpack serve",
     "test": "node testsBrowser/start.js",
     "test:all": "node testsBrowser/start.js --task runAll --verbose",
     "test:list": "node testsBrowser/start.js --list",


### PR DESCRIPTION
cf. https://coopmaths.slack.com/archives/C01V5H69J8Y/p1667388138533329?thread_ts=1667292022.850779&cid=C01V5H69J8Y