### PR TITLE
fix: nommePolygone() n'était pas compatible avec des noms de 2 caractères

### DIFF
--- a/src/js/modules/2d.js
+++ b/src/js/modules/2d.js
@@ -594,6 +594,7 @@ export function LabelPoint (...points) {
       this.listePoints = points
     }
     for (const unPoint of this.listePoints) {
+      console.log(unPoint)
       if (unPoint.typeObjet === 'point3d') {
         A = unPoint.c2d
       } else {
@@ -2722,7 +2723,8 @@ export function polygoneAvecNom (...args) {
   }
   const p = polygone(...args)
   let nom = ''
-  args.forEach(el => (nom += el.nom))
+  args.forEach(el => (nom += el.nom + ','))
+  nom = nom.substring(0, nom.length - 1)
   p.sommets = nommePolygone(p, nom, k)
   p.sommets.bordures = []
   p.sommets.bordures[0] = p.bordures[0] - 1 - k
@@ -2733,9 +2735,13 @@ export function polygoneAvecNom (...args) {
 }
 
 /**
- * Renomme en une fois tous les sommets d'un polygone avec le tableau de string fourni
+ * @description en une fois tous les sommets d'un polygone avec le tableau de string fourni
+ * attention si on passe un string comme 'ABCD' ça fonctionne aussi...
+ * Si on veut des noms de points à plus de 1 caractère, il faut soit les passer en tableau soit les séparer par des virgules au sein du string
+ * @example renommePolygone(p, "A',B',C',D'") ou renommePolygone(p, ["A'","B'","C'","D'"])
  */
 export function renommePolygone (p, noms) {
+  noms = (typeof noms === 'string') ? noms.includes(',') ? noms.split(',') : noms : noms
   for (let i = 0; i < p.listePoints.length; i++) {
     if (noms[i] !== undefined) {
       p.listePoints[i].nom = noms[i]
@@ -3212,15 +3218,19 @@ export function parallelogramme2points1hauteur (NOM, A, B, h, color = 'black') {
 }
 
 /**
- * nommePolygone (p,'ABCDE',0.5,'red') nomme les sommets du polygone p. Les labels sont placés à une distance paramètrable en cm des sommets (0.5 par défaut)
+ * @description Place les labels passés dans le deuxième paramètre aux sommets du polygone en les plaçant alignés avec le barycentre du polygone à une distance fixée du point
+ * @description Si les noms peuvent avoir plusieurs caractères, il faudra ajouter des virgules entre chaque nom dans le string passé en argument.
+ * @example nommePolygone (p, "A',B',C',D',E'", 0.5, 'red')
+ * @example nommePolygone (p,'ABCDE',0.5,'red') nomme les sommets du polygone A, B, C, D et E. Les labels sont placés à une distance de 0,5 cm des sommets
  * @author Jean-Claude Lhote
  */
 export function NommePolygone (p, nom = '', k = 0.5, color = 'black') {
   ObjetMathalea2D.call(this, { })
   this.poly = p
   this.dist = k
+  const noms = nom.includes(',') ? nom.split(',') : nom
   for (let i = 0; i < p.listePoints.length; i++) {
-    if (nom !== '') p.listePoints[i].nom = nom[i]
+    if (noms.length > 0) p.listePoints[i].nom = noms[i]
   }
   this.svg = function (coeff) {
     let code = ''
@@ -5322,6 +5332,7 @@ export function symetrieAxiale (A, d, nom = '', positionLabel = 'above', color =
       x = k * ((b * b - a * a) * A.x - 2 * a * b * A.y - 2 * a * c)
       y = k * ((a * a - b * b) * A.y - 2 * a * b * A.x + (a * a * c) / b - b * c) - c / b
     }
+    console.log(nom)
     return point(x, y, nom, positionLabel)
   }
   if (A.constructor === Polygone) {


### PR DESCRIPTION
PolygoneAvecNom() a été modifié pour passer à nommePolygone() un string formaté avec des virgules au cas où les noms aient plus d'un caractère.