### PR TITLE
fix; provisoirement je remplace l'alerte par un console.error()

### DIFF
--- a/src/js/firstLoaded.js
+++ b/src/js/firstLoaded.js
@@ -1,10 +1,11 @@
 // fonction globale pour notifier des erreurs potentielles dans le code.
 import Bugsnag from '@bugsnag/js'
 import { tropDeChiffres } from './modules/outils'
+// @todo regarder pourquoi window.Bugsnag n'est pas défini et donc les signalements sont balancés dans la console alors qu'on est en ligne !
 window.notify = function notify (error, metadatas) {
   if (typeof error === 'string') {
     if (error.includes(tropDeChiffres) && !window.Bugsnag) {
-      alert(error + '\nIl y a un risque d\'erreur d\'approximation (la limite est de 15 chiffres significatifs)\nnb : ' + metadatas.nb + '\nprecision (= nombre de décimales demandé) : ' + metadatas.precision)
+      console.error(error + '\nIl y a un risque d\'erreur d\'approximation (la limite est de 15 chiffres significatifs)\nnb : ' + metadatas.nb + '\nprecision (= nombre de décimales demandé) : ' + metadatas.precision)
     }
     error = Error(error)
   }


### PR DESCRIPTION
Mais il faut se pencher sur le comportement de window.notify() en ligne : actuellement, il émet dans la console des messages qui devraient être envoyés à Bugsnag